### PR TITLE
Format error messages as filename:line:col: error: message

### DIFF
--- a/tup/parse/error.go
+++ b/tup/parse/error.go
@@ -10,6 +10,7 @@ import (
 var ErrNoMatch = errors.New("no match")
 
 type Error struct {
+	Filename  string
 	Expecting string
 	Got       string
 	Line      int
@@ -19,15 +20,21 @@ type Error struct {
 }
 
 func (err *Error) Error() string {
-	if len(err.SubErrors) > 0 {
-		return fmt.Sprintf(`expecting %#v, got %#v at row %d, col %d: %v`, err.Expecting, err.Got, err.Line+1, err.Column+1, err.SubErrors)
+	loc := fmt.Sprintf("%d:%d", err.Line+1, err.Column+1)
+	if err.Filename != "" {
+		loc = fmt.Sprintf("%s:%d:%d", err.Filename, err.Line+1, err.Column+1)
 	}
-	return fmt.Sprintf(`expecting %#v, got %#v at row %d, col %d`, err.Expecting, err.Got, err.Line+1, err.Column+1)
+	msg := fmt.Sprintf("expecting %#v, got %#v", err.Expecting, err.Got)
+	if len(err.SubErrors) > 0 {
+		return fmt.Sprintf("%s: error: %s: %v", loc, msg, err.SubErrors)
+	}
+	return fmt.Sprintf("%s: error: %s", loc, msg)
 }
 
 func errorExpecting(expecting string, tokens []tok.Token) *Error {
-	got, line, column := errorGot(tokens)
+	filename, got, line, column := errorGot(tokens)
 	return &Error{
+		Filename:  filename,
 		Expecting: expecting,
 		Got:       got,
 		Line:      line,
@@ -38,8 +45,9 @@ func errorExpecting(expecting string, tokens []tok.Token) *Error {
 }
 
 func errorExpectingOneOf(expecting string, tokens []tok.Token, errors []error) *Error {
-	got, line, column := errorGot(tokens)
+	filename, got, line, column := errorGot(tokens)
 	return &Error{
+		Filename:  filename,
 		Expecting: expecting,
 		Got:       got,
 		Line:      line,
@@ -50,8 +58,9 @@ func errorExpectingOneOf(expecting string, tokens []tok.Token, errors []error) *
 }
 
 func errorExpectingTokenType(tokenType tok.TokenType, tokens []tok.Token) *Error {
-	got, line, column := errorGot(tokens)
+	filename, got, line, column := errorGot(tokens)
 	return &Error{
+		Filename:  filename,
 		Expecting: tok.TokenTypes[tokenType],
 		Got:       got,
 		Line:      line,
@@ -62,8 +71,9 @@ func errorExpectingTokenType(tokenType tok.TokenType, tokens []tok.Token) *Error
 }
 
 func errorNotExpecting(tokens []tok.Token) *Error {
-	got, line, column := errorGot(tokens)
+	filename, got, line, column := errorGot(tokens)
 	return &Error{
+		Filename:  filename,
 		Expecting: "not " + got,
 		Got:       got,
 		Line:      line,
@@ -71,12 +81,15 @@ func errorNotExpecting(tokens []tok.Token) *Error {
 	}
 }
 
-func errorGot(tokens []tok.Token) (got string, line int, column int) {
+func errorGot(tokens []tok.Token) (filename string, got string, line int, column int) {
 	tokens = skipTrivia(tokens)
 	if len(tokens) > 0 {
+		if tokens[0].File != nil {
+			filename = tokens[0].File.Filename
+		}
 		got = tokens[0].Value()
 		line = tokens[0].Line()
 		column = tokens[0].Column()
 	}
-	return got, line, column
+	return filename, got, line, column
 }

--- a/tup/parse/error.go
+++ b/tup/parse/error.go
@@ -22,13 +22,13 @@ type Error struct {
 func (err *Error) Error() string {
 	loc := fmt.Sprintf("%d:%d", err.Line+1, err.Column+1)
 	if err.Filename != "" {
-		loc = fmt.Sprintf("%s:%d:%d", err.Filename, err.Line+1, err.Column+1)
+		loc = fmt.Sprintf("--> %s:%d:%d", err.Filename, err.Line+1, err.Column+1)
 	}
-	msg := fmt.Sprintf("expecting %#v, got %#v", err.Expecting, err.Got)
+	msg := fmt.Sprintf("error: expecting %#v, got %#v", err.Expecting, err.Got)
 	if len(err.SubErrors) > 0 {
-		return fmt.Sprintf("%s: error: %s: %v", loc, msg, err.SubErrors)
+		return fmt.Sprintf("%s: %v\n%s", msg, err.SubErrors, loc)
 	}
-	return fmt.Sprintf("%s: error: %s", loc, msg)
+	return fmt.Sprintf("%s\n%s", msg, loc)
 }
 
 func errorExpecting(expecting string, tokens []tok.Token) *Error {

--- a/tup/parse/testdata/error/output/assignments.tup
+++ b/tup/parse/testdata/error/output/assignments.tup
@@ -1,8 +1,8 @@
 # missing right-hand side
-expecting "expression", got "" at row 1, col 9
+/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:9: error: expecting "expression", got ""
 
 # unclosed labeled destructuring
-expecting ")", got "=" at row 1, col 12
+/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:12: error: expecting ")", got "="
 
 # missing expression after mut
-expecting "expression", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:13: error: expecting "expression", got ""

--- a/tup/parse/testdata/error/output/assignments.tup
+++ b/tup/parse/testdata/error/output/assignments.tup
@@ -1,8 +1,11 @@
 # missing right-hand side
-/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:9: error: expecting "expression", got ""
+error: expecting "expression", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:9
 
 # unclosed labeled destructuring
-/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:12: error: expecting ")", got "="
+error: expecting ")", got "="
+--> /home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:12
 
 # missing expression after mut
-/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:13: error: expecting "expression", got ""
+error: expecting "expression", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:13

--- a/tup/parse/testdata/error/output/expressions.tup
+++ b/tup/parse/testdata/error/output/expressions.tup
@@ -1,41 +1,41 @@
 # unclosed tuple literal
-expecting ")", got "" at row 1, col 10
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10: error: expecting ")", got ""
 
 # unclosed array literal
-expecting "]", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting "]", got ""
 
 # binary expression missing right operand
-expecting "expression", got "" at row 1, col 8
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:8: error: expecting "expression", got ""
 
 # unclosed block
-expecting "}", got "" at row 3, col 6
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:3:6: error: expecting "}", got ""
 
 # if expression missing condition
-expecting "expression", got "" at row 1, col 7
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7: error: expecting "expression", got ""
 
 # if expression missing then branch
-expecting "block", got "" at row 1, col 12
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12: error: expecting "block", got ""
 
 # if expression with block condition missing then branch
-expecting "block", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting "block", got ""
 
 # function call missing closing paren
-expecting ")", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting ")", got ""
 
 # labeled tuple literal missing colon
-expecting "expression", got "(" at row 1, col 5
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:5: error: expecting "expression", got "("
 
 # labeled tuple literal trailing unlabeled member
-expecting ")", got "c" at row 1, col 18
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:18: error: expecting ")", got "c"
 
 # member access missing field name
-expecting "field name", got "" at row 1, col 10
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10: error: expecting "field name", got ""
 
 # tuple update with unlabeled tuple
-expecting "field name", got "1" at row 1, col 11
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:11: error: expecting "field name", got "1"
 
 # import with identifier instead of string
-expecting "string literal", got "io" at row 1, col 12
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12: error: expecting "string literal", got "io"
 
 # meta expression missing labeled arguments
-expecting "labeled argument", got ")" at row 1, col 7
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7: error: expecting "labeled argument", got ")"

--- a/tup/parse/testdata/error/output/expressions.tup
+++ b/tup/parse/testdata/error/output/expressions.tup
@@ -1,41 +1,55 @@
 # unclosed tuple literal
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10: error: expecting ")", got ""
+error: expecting ")", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10
 
 # unclosed array literal
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting "]", got ""
+error: expecting "]", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13
 
 # binary expression missing right operand
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:8: error: expecting "expression", got ""
+error: expecting "expression", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:8
 
 # unclosed block
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:3:6: error: expecting "}", got ""
+error: expecting "}", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:3:6
 
 # if expression missing condition
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7: error: expecting "expression", got ""
+error: expecting "expression", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7
 
 # if expression missing then branch
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12: error: expecting "block", got ""
+error: expecting "block", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12
 
 # if expression with block condition missing then branch
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting "block", got ""
+error: expecting "block", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13
 
 # function call missing closing paren
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting ")", got ""
+error: expecting ")", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13
 
 # labeled tuple literal missing colon
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:5: error: expecting "expression", got "("
+error: expecting "expression", got "("
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:5
 
 # labeled tuple literal trailing unlabeled member
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:18: error: expecting ")", got "c"
+error: expecting ")", got "c"
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:18
 
 # member access missing field name
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10: error: expecting "field name", got ""
+error: expecting "field name", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10
 
 # tuple update with unlabeled tuple
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:11: error: expecting "field name", got "1"
+error: expecting "field name", got "1"
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:11
 
 # import with identifier instead of string
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12: error: expecting "string literal", got "io"
+error: expecting "string literal", got "io"
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12
 
 # meta expression missing labeled arguments
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7: error: expecting "labeled argument", got ")"
+error: expecting "labeled argument", got ")"
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7

--- a/tup/parse/testdata/error/output/function_declarations.tup
+++ b/tup/parse/testdata/error/output/function_declarations.tup
@@ -1,11 +1,11 @@
 # missing function body
-expecting "function body", got "" at row 1, col 29
+/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:29: error: expecting "function body", got ""
 
 # missing return type for fn
-expecting "return type or _", got "{" at row 1, col 26
+/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:26: error: expecting "return type or _", got "{"
 
 # unclosed parameter list
-expecting ")", got "" at row 3, col 2
+/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:3:2: error: expecting ")", got ""
 
 # function body missing closing brace
-expecting "}", got "" at row 2, col 10
+/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:2:10: error: expecting "}", got ""

--- a/tup/parse/testdata/error/output/function_declarations.tup
+++ b/tup/parse/testdata/error/output/function_declarations.tup
@@ -1,11 +1,15 @@
 # missing function body
-/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:29: error: expecting "function body", got ""
+error: expecting "function body", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:29
 
 # missing return type for fn
-/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:26: error: expecting "return type or _", got "{"
+error: expecting "return type or _", got "{"
+--> /home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:26
 
 # unclosed parameter list
-/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:3:2: error: expecting ")", got ""
+error: expecting ")", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:3:2
 
 # function body missing closing brace
-/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:2:10: error: expecting "}", got ""
+error: expecting "}", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:2:10

--- a/tup/parse/testdata/error/output/nested_errors.tup
+++ b/tup/parse/testdata/error/output/nested_errors.tup
@@ -1,17 +1,23 @@
 # binary expression missing operand in function body
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36: error: expecting "expression", got "}"
+error: expecting "expression", got "}"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36
 
 # binary expression missing operand in block expression
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:5:1: error: expecting "expression", got "}"
+error: expecting "expression", got "}"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:5:1
 
 # binary expression missing operand in function call argument
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:13: error: expecting "expression", got ")"
+error: expecting "expression", got ")"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:13
 
 # nested call missing closing paren
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22: error: expecting ")", got ""
+error: expecting ")", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22
 
 # binary expression missing operand in array initializer closure
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22: error: expecting "expression", got "}"
+error: expecting "expression", got "}"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22
 
 # if expression missing then branch inside function body
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36: error: expecting "block", got "}"
+error: expecting "block", got "}"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36

--- a/tup/parse/testdata/error/output/nested_errors.tup
+++ b/tup/parse/testdata/error/output/nested_errors.tup
@@ -1,17 +1,17 @@
 # binary expression missing operand in function body
-expecting "expression", got "}" at row 1, col 36
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36: error: expecting "expression", got "}"
 
 # binary expression missing operand in block expression
-expecting "expression", got "}" at row 5, col 1
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:5:1: error: expecting "expression", got "}"
 
 # binary expression missing operand in function call argument
-expecting "expression", got ")" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:13: error: expecting "expression", got ")"
 
 # nested call missing closing paren
-expecting ")", got "" at row 1, col 22
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22: error: expecting ")", got ""
 
 # binary expression missing operand in array initializer closure
-expecting "expression", got "}" at row 1, col 22
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22: error: expecting "expression", got "}"
 
 # if expression missing then branch inside function body
-expecting "block", got "}" at row 1, col 36
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36: error: expecting "block", got "}"

--- a/tup/parse/testdata/error/output/type_declarations.tup
+++ b/tup/parse/testdata/error/output/type_declarations.tup
@@ -1,14 +1,19 @@
 # missing type body
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:13: error: expecting "tuple type", got ""
+error: expecting "tuple type", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:13
 
 # unclosed tuple type
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:24: error: expecting "field name", got ""
+error: expecting "field name", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:24
 
 # type keyword not followed by tuple body
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:14: error: expecting "tuple type", got "Circle"
+error: expecting "tuple type", got "Circle"
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:14
 
 # union type missing variant after pipe
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:28: error: expecting "union member", got ""
+error: expecting "union member", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:28
 
 # tuple type mixed labeled and unlabeled members
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:29: error: expecting "field name", got "Int"
+error: expecting "field name", got "Int"
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:29

--- a/tup/parse/testdata/error/output/type_declarations.tup
+++ b/tup/parse/testdata/error/output/type_declarations.tup
@@ -1,14 +1,14 @@
 # missing type body
-expecting "tuple type", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:13: error: expecting "tuple type", got ""
 
 # unclosed tuple type
-expecting "field name", got "" at row 1, col 24
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:24: error: expecting "field name", got ""
 
 # type keyword not followed by tuple body
-expecting "tuple type", got "Circle" at row 1, col 14
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:14: error: expecting "tuple type", got "Circle"
 
 # union type missing variant after pipe
-expecting "union member", got "" at row 1, col 28
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:28: error: expecting "union member", got ""
 
 # tuple type mixed labeled and unlabeled members
-expecting "field name", got "Int" at row 1, col 29
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:29: error: expecting "field name", got "Int"

--- a/tup/parse/testdata/error/review/assignments.tup
+++ b/tup/parse/testdata/error/review/assignments.tup
@@ -1,14 +1,17 @@
 # missing right-hand side
 answer =
 
-/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:9: error: expecting "expression", got ""
+error: expecting "expression", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:9
 
 # unclosed labeled destructuring
 (name, age = (name: "Brent", age: 42)
 
-/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:12: error: expecting ")", got "="
+error: expecting ")", got "="
+--> /home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:12
 
 # missing expression after mut
 coords = mut
 
-/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:13: error: expecting "expression", got ""
+error: expecting "expression", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:13

--- a/tup/parse/testdata/error/review/assignments.tup
+++ b/tup/parse/testdata/error/review/assignments.tup
@@ -1,14 +1,14 @@
 # missing right-hand side
 answer =
 
-expecting "expression", got "" at row 1, col 9
+/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:9: error: expecting "expression", got ""
 
 # unclosed labeled destructuring
 (name, age = (name: "Brent", age: 42)
 
-expecting ")", got "=" at row 1, col 12
+/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:12: error: expecting ")", got "="
 
 # missing expression after mut
 coords = mut
 
-expecting "expression", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/assignments.tup:1:13: error: expecting "expression", got ""

--- a/tup/parse/testdata/error/review/expressions.tup
+++ b/tup/parse/testdata/error/review/expressions.tup
@@ -1,71 +1,85 @@
 # unclosed tuple literal
 _ = (1, 2
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10: error: expecting ")", got ""
+error: expecting ")", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10
 
 # unclosed array literal
 _ = [1, 2, 3
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting "]", got ""
+error: expecting "]", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13
 
 # binary expression missing right operand
 _ = 1 +
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:8: error: expecting "expression", got ""
+error: expecting "expression", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:8
 
 # unclosed block
 _ = {
     x = 1
     x
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:3:6: error: expecting "}", got ""
+error: expecting "}", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:3:6
 
 # if expression missing condition
 _ = if
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7: error: expecting "expression", got ""
+error: expecting "expression", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7
 
 # if expression missing then branch
 _ = if true
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12: error: expecting "block", got ""
+error: expecting "block", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12
 
 # if expression with block condition missing then branch
 _ = if { 1 }
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting "block", got ""
+error: expecting "block", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13
 
 # function call missing closing paren
 _ = foo(1, 2
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting ")", got ""
+error: expecting ")", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13
 
 # labeled tuple literal missing colon
 _ = (a 1, b: 2, c: 3)
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:5: error: expecting "expression", got "("
+error: expecting "expression", got "("
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:5
 
 # labeled tuple literal trailing unlabeled member
 _ = (a: 1, b: 2, c)
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:18: error: expecting ")", got "c"
+error: expecting ")", got "c"
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:18
 
 # member access missing field name
 _ = user.
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10: error: expecting "field name", got ""
+error: expecting "field name", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10
 
 # tuple update with unlabeled tuple
 _ = user.(1, 2)
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:11: error: expecting "field name", got "1"
+error: expecting "field name", got "1"
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:11
 
 # import with identifier instead of string
 _ = import(io)
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12: error: expecting "string literal", got "io"
+error: expecting "string literal", got "io"
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12
 
 # meta expression missing labeled arguments
 _ = $()
 
-/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7: error: expecting "labeled argument", got ")"
+error: expecting "labeled argument", got ")"
+--> /home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7

--- a/tup/parse/testdata/error/review/expressions.tup
+++ b/tup/parse/testdata/error/review/expressions.tup
@@ -1,71 +1,71 @@
 # unclosed tuple literal
 _ = (1, 2
 
-expecting ")", got "" at row 1, col 10
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10: error: expecting ")", got ""
 
 # unclosed array literal
 _ = [1, 2, 3
 
-expecting "]", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting "]", got ""
 
 # binary expression missing right operand
 _ = 1 +
 
-expecting "expression", got "" at row 1, col 8
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:8: error: expecting "expression", got ""
 
 # unclosed block
 _ = {
     x = 1
     x
 
-expecting "}", got "" at row 3, col 6
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:3:6: error: expecting "}", got ""
 
 # if expression missing condition
 _ = if
 
-expecting "expression", got "" at row 1, col 7
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7: error: expecting "expression", got ""
 
 # if expression missing then branch
 _ = if true
 
-expecting "block", got "" at row 1, col 12
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12: error: expecting "block", got ""
 
 # if expression with block condition missing then branch
 _ = if { 1 }
 
-expecting "block", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting "block", got ""
 
 # function call missing closing paren
 _ = foo(1, 2
 
-expecting ")", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:13: error: expecting ")", got ""
 
 # labeled tuple literal missing colon
 _ = (a 1, b: 2, c: 3)
 
-expecting "expression", got "(" at row 1, col 5
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:5: error: expecting "expression", got "("
 
 # labeled tuple literal trailing unlabeled member
 _ = (a: 1, b: 2, c)
 
-expecting ")", got "c" at row 1, col 18
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:18: error: expecting ")", got "c"
 
 # member access missing field name
 _ = user.
 
-expecting "field name", got "" at row 1, col 10
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:10: error: expecting "field name", got ""
 
 # tuple update with unlabeled tuple
 _ = user.(1, 2)
 
-expecting "field name", got "1" at row 1, col 11
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:11: error: expecting "field name", got "1"
 
 # import with identifier instead of string
 _ = import(io)
 
-expecting "string literal", got "io" at row 1, col 12
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:12: error: expecting "string literal", got "io"
 
 # meta expression missing labeled arguments
 _ = $()
 
-expecting "labeled argument", got ")" at row 1, col 7
+/home/user/tuppence/tup/parse/testdata/error/input/expressions.tup:1:7: error: expecting "labeled argument", got ")"

--- a/tup/parse/testdata/error/review/function_declarations.tup
+++ b/tup/parse/testdata/error/review/function_declarations.tup
@@ -1,24 +1,24 @@
 # missing function body
 add = fn(x: Int, y: Int) Int
 
-expecting "function body", got "" at row 1, col 29
+/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:29: error: expecting "function body", got ""
 
 # missing return type for fn
 add = fn(x: Int, y: Int) {
     x + y
 }
 
-expecting "return type or _", got "{" at row 1, col 26
+/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:26: error: expecting "return type or _", got "{"
 
 # unclosed parameter list
 add = fn(x: Int, y: Int {
     x + y
 }
 
-expecting ")", got "" at row 3, col 2
+/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:3:2: error: expecting ")", got ""
 
 # function body missing closing brace
 add = fn(x: Int, y: Int) Int {
     x + y
 
-expecting "}", got "" at row 2, col 10
+/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:2:10: error: expecting "}", got ""

--- a/tup/parse/testdata/error/review/function_declarations.tup
+++ b/tup/parse/testdata/error/review/function_declarations.tup
@@ -1,24 +1,28 @@
 # missing function body
 add = fn(x: Int, y: Int) Int
 
-/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:29: error: expecting "function body", got ""
+error: expecting "function body", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:29
 
 # missing return type for fn
 add = fn(x: Int, y: Int) {
     x + y
 }
 
-/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:26: error: expecting "return type or _", got "{"
+error: expecting "return type or _", got "{"
+--> /home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:1:26
 
 # unclosed parameter list
 add = fn(x: Int, y: Int {
     x + y
 }
 
-/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:3:2: error: expecting ")", got ""
+error: expecting ")", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:3:2
 
 # function body missing closing brace
 add = fn(x: Int, y: Int) Int {
     x + y
 
-/home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:2:10: error: expecting "}", got ""
+error: expecting "}", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/function_declarations.tup:2:10

--- a/tup/parse/testdata/error/review/nested_errors.tup
+++ b/tup/parse/testdata/error/review/nested_errors.tup
@@ -1,7 +1,8 @@
 # binary expression missing operand in function body
 add = fn(x: Int, y: Int) Int { x + }
 
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36: error: expecting "expression", got "}"
+error: expecting "expression", got "}"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36
 
 # binary expression missing operand in block expression
 result = {
@@ -10,24 +11,29 @@ result = {
     x +
 }
 
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:5:1: error: expecting "expression", got "}"
+error: expecting "expression", got "}"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:5:1
 
 # binary expression missing operand in function call argument
 _ = foo(1 + )
 
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:13: error: expecting "expression", got ")"
+error: expecting "expression", got ")"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:13
 
 # nested call missing closing paren
 _ = outer(inner(1, 2)
 
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22: error: expecting ")", got ""
+error: expecting ")", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22
 
 # binary expression missing operand in array initializer closure
 _ = [4]Int { |i| i * }
 
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22: error: expecting "expression", got "}"
+error: expecting "expression", got "}"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22
 
 # if expression missing then branch inside function body
 check = fn(x: Int) Bool { if x > 0 }
 
-/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36: error: expecting "block", got "}"
+error: expecting "block", got "}"
+--> /home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36

--- a/tup/parse/testdata/error/review/nested_errors.tup
+++ b/tup/parse/testdata/error/review/nested_errors.tup
@@ -1,7 +1,7 @@
 # binary expression missing operand in function body
 add = fn(x: Int, y: Int) Int { x + }
 
-expecting "expression", got "}" at row 1, col 36
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36: error: expecting "expression", got "}"
 
 # binary expression missing operand in block expression
 result = {
@@ -10,24 +10,24 @@ result = {
     x +
 }
 
-expecting "expression", got "}" at row 5, col 1
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:5:1: error: expecting "expression", got "}"
 
 # binary expression missing operand in function call argument
 _ = foo(1 + )
 
-expecting "expression", got ")" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:13: error: expecting "expression", got ")"
 
 # nested call missing closing paren
 _ = outer(inner(1, 2)
 
-expecting ")", got "" at row 1, col 22
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22: error: expecting ")", got ""
 
 # binary expression missing operand in array initializer closure
 _ = [4]Int { |i| i * }
 
-expecting "expression", got "}" at row 1, col 22
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:22: error: expecting "expression", got "}"
 
 # if expression missing then branch inside function body
 check = fn(x: Int) Bool { if x > 0 }
 
-expecting "block", got "}" at row 1, col 36
+/home/user/tuppence/tup/parse/testdata/error/input/nested_errors.tup:1:36: error: expecting "block", got "}"

--- a/tup/parse/testdata/error/review/type_declarations.tup
+++ b/tup/parse/testdata/error/review/type_declarations.tup
@@ -1,24 +1,24 @@
 # missing type body
 Point = type
 
-expecting "tuple type", got "" at row 1, col 13
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:13: error: expecting "tuple type", got ""
 
 # unclosed tuple type
 Point = type (x: Float,
 
-expecting "field name", got "" at row 1, col 24
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:24: error: expecting "field name", got ""
 
 # type keyword not followed by tuple body
 Shape = type Circle | Triangle |
 
-expecting "tuple type", got "Circle" at row 1, col 14
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:14: error: expecting "tuple type", got "Circle"
 
 # union type missing variant after pipe
 Shape = Circle | Triangle |
 
-expecting "union member", got "" at row 1, col 28
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:28: error: expecting "union member", got ""
 
 # tuple type mixed labeled and unlabeled members
 Point = type (name: String, Int)
 
-expecting "field name", got "Int" at row 1, col 29
+/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:29: error: expecting "field name", got "Int"

--- a/tup/parse/testdata/error/review/type_declarations.tup
+++ b/tup/parse/testdata/error/review/type_declarations.tup
@@ -1,24 +1,29 @@
 # missing type body
 Point = type
 
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:13: error: expecting "tuple type", got ""
+error: expecting "tuple type", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:13
 
 # unclosed tuple type
 Point = type (x: Float,
 
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:24: error: expecting "field name", got ""
+error: expecting "field name", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:24
 
 # type keyword not followed by tuple body
 Shape = type Circle | Triangle |
 
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:14: error: expecting "tuple type", got "Circle"
+error: expecting "tuple type", got "Circle"
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:14
 
 # union type missing variant after pipe
 Shape = Circle | Triangle |
 
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:28: error: expecting "union member", got ""
+error: expecting "union member", got ""
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:28
 
 # tuple type mixed labeled and unlabeled members
 Point = type (name: String, Int)
 
-/home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:29: error: expecting "field name", got "Int"
+error: expecting "field name", got "Int"
+--> /home/user/tuppence/tup/parse/testdata/error/input/type_declarations.tup:1:29


### PR DESCRIPTION
Matches the convention used by GCC, Clang, and Go, enabling
terminal click shortcuts and editor navigation to source locations.

Also adds Filename field to parse.Error and removes the non-standard
"at row N, col M" phrasing in favour of the leading location prefix.

https://claude.ai/code/session_01CZQQ432w24HD7GKRPrvWMz